### PR TITLE
fix: add leader election ID flag to main configuration

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,12 +32,14 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionID string
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&leaderElectionID, "leader-election-id", "evicted-pod-reaper.kyos.com", "Leader election ID to use.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -63,7 +65,7 @@ func main() {
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "evicted-pod-reaper.kyos.com",
+		LeaderElectionID:       leaderElectionID,
 	}
 
 	// Configure namespace watching


### PR DESCRIPTION
This pull request introduces a small but useful improvement to the controller manager's configuration by making the leader election ID configurable via a command-line flag, instead of being hardcoded. This enhances flexibility when deploying the controller in different environments.

Configuration improvements:

* Added a new `--leader-election-id` command-line flag to allow users to specify the leader election ID, replacing the previously hardcoded value in `main.go`. [[1]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R35-R42) [[2]](diffhunk://#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633L66-R68)