### PR TITLE
feat: Update predicate in pod controller to only watch evicted pods

### DIFF
--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -392,18 +391,10 @@ func TestPodReconciler_EvictedPredicate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a predicate function that matches the one in SetupWithManager
-			evictedPredicate := func(obj client.Object) bool {
-				pod, ok := obj.(*corev1.Pod)
-				if !ok {
-					return false
-				}
-				return pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "Evicted"
-			}
-
-			got := evictedPredicate(tt.pod)
+			// Use the shared predicate function from the controller
+			got := isEvictedPodPredicate(tt.pod)
 			if got != tt.want {
-				t.Errorf("evictedPredicate() = %v, want %v", got, tt.want)
+				t.Errorf("isEvictedPodPredicate() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request updates the controller logic to ensure it only watches Kubernetes pods that have failed specifically due to eviction, rather than all failed pods. It also adds comprehensive unit tests to verify this new predicate logic.

**Controller logic update:**

* The `SetupWithManager` method in `pod_controller.go` now uses a predicate that filters only for pods in the `Failed` phase with the reason `"Evicted"`, instead of all failed pods.

**Testing improvements:**

* Added a new test, `TestPodReconciler_EvictedPredicate`, in `pod_controller_test.go` to verify that the predicate correctly matches only evicted pods and excludes other failure reasons or pod phases.
* Added the necessary import for `client.Object` in the test file to support the new test.